### PR TITLE
Simplify null & undefined checks

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,6 +1,6 @@
 "use strict";
 
-if (typeof global.localStorage === "undefined" || global.localStorage === null) {
+if (typeof global.localStorage == null) {
     var LocalStorage = require('node-localstorage').LocalStorage;
     global.localStorage = new LocalStorage('./data', Number.MAX_VALUE);
 }


### PR DESCRIPTION
Check only for null with two equal signs: == .
This will treat null and undefined as equal. 

see:
console.log(null == undefined); // true
console.log(null === undefined); // false